### PR TITLE
FIX cronjobs should build master

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@
 # Windows
 
 environment:
-  BUILD_COMMIT: v0.15.0
+  BUILD_COMMIT: master
   REPO_DIR: scikit-image
   PKG_NAME: scikit_image
   WHEELHOUSE_UPLOADER_USERNAME: travis-worker
@@ -15,8 +15,6 @@ environment:
   DAILY_COMMIT: master
 
   matrix:
-    - PYTHON: C:\Python35
-    - PYTHON: C:\Python35-x64
     - PYTHON: C:\Python36
       NP_BUILD_DEP: "numpy==1.13.3"
       NP_TEST_DEP: "numpy==1.13.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,9 @@ script:
 after_success:
     # Upload wheels to Rackspace container
     - pip install wheelhouse-uploader
-    - travis_wait 40 python -m wheelhouse_uploader upload --local-folder
-          ${TRAVIS_BUILD_DIR}/wheelhouse/
+    - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ];
+       then travis_wait 40 python -m wheelhouse_uploader upload
+          --local-folder ${TRAVIS_BUILD_DIR}/wheelhouse/
           $UPLOAD_ARGS
-          $CONTAINER
+          $CONTAINER;
+       fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ env:
   global:
       - REPO_DIR="scikit-image"
       # Also see DAILY_COMMIT below
-      - BUILD_COMMIT=v0.15.0
+      - BUILD_COMMIT=master
       - PLAT=x86_64
       - UNICODE_WIDTH=32
       - NP_BUILD_DEP="numpy==1.13.3"
@@ -30,17 +30,6 @@ matrix:
   include:
     - os: linux
       env:
-        - MB_PYTHON_VERSION=3.5
-        - NP_BUILD_DEP=numpy==1.13.3
-        - NP_TEST_DEP=numpy==1.13.3
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.5
-        - PLAT=i686
-        - NP_BUILD_DEP=numpy==1.13.3
-        - NP_TEST_DEP=numpy==1.13.3
-    - os: linux
-      env:
         - MB_PYTHON_VERSION=3.6
         - NP_BUILD_DEP=numpy==1.13.3
         - NP_TEST_DEP=numpy==1.13.3
@@ -61,12 +50,6 @@ matrix:
         - PLAT=i686
         - NP_BUILD_DEP=numpy==1.14.5
         - NP_TEST_DEP=numpy==1.14.5
-    - os: osx
-      language: generic
-      env:
-        - MB_PYTHON_VERSION=3.5
-        - NP_BUILD_DEP=numpy==1.13.3
-        - NP_TEST_DEP=numpy==1.13.3
     - os: osx
       language: generic
       env:
@@ -105,7 +88,7 @@ script:
 after_success:
     # Upload wheels to Rackspace container
     - pip install wheelhouse-uploader
-    - python -m wheelhouse_uploader upload --local-folder
+    - travis_wait 40 python -m wheelhouse_uploader upload --local-folder
           ${TRAVIS_BUILD_DIR}/wheelhouse/
           $UPLOAD_ARGS
           $CONTAINER


### PR DESCRIPTION
This PR should fix the builds on master.
1. the master branch was not building the right branch.
2. python3.5 is not supported anymore.
3. multibuild needs to be updated.

There might also be an API key problem, but we will not be able to detect this from this PR nor whether the CI pass.