### PR TITLE
Upload to anaconda.org instead of Rackspace

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,10 +6,6 @@ environment:
   REPO_DIR: scikit-image
   PKG_NAME: scikit_image
   WHEELHOUSE_UPLOADER_USERNAME: travis-worker
-  # https://www.appveyor.com/docs/build-configuration/#secure-variables
-  # Encrypted to matthew-brett account, for now.
-  WHEELHOUSE_UPLOADER_SECRET:
-    secure: ozQ/OF7YF5bsfSd9CKAREE1YKWQy6ucciQ7446lFcJONOBG+/yvYtpPkpv4Dqrp7
   NP_BUILD_DEP: "numpy==1.14.5"
   NP_TEST_DEP: "numpy==1.14.5"
   DAILY_COMMIT: master
@@ -35,11 +31,10 @@ init:
   - "ECHO \"%APPVEYOR_SCHEDULED_BUILD%\""
   - ps: >-
       if ($env:APPVEYOR_REPO_BRANCH -eq "master") {
-        $env:CONTAINER = "pre-release"
+        $env:ANACONDA_ORG = "scipy-wheels-nightly"
         if ($env:DAILY_COMMIT) { $env:BUILD_COMMIT = $env:DAILY_COMMIT }
       } else {
-        $env:CONTAINER = "wheels"
-        $env:UPLOAD_ARGS = "--no-update-index"
+        $env:ANACONDA_ORG = "multibuild-wheels-staging"
       }
 
 install:
@@ -96,14 +91,13 @@ test_script:
   - cd ..
 
 on_success:
-  # Upload the generated wheel package to Rackspace
-  # On Windows, Apache Libcloud cannot find a standard CA cert bundle so we
-  # disable the ssl checks.
-  - pip install wheelhouse-uploader
-  - python -m wheelhouse_uploader upload
-    --local-folder=%REPO_DIR%\dist
-    %UPLOAD_ARGS%
-    %CONTAINER%
+  # Upload the generated wheel package to anaconda.org
+  # PYWAVELETS_STAGING_UPLOAD_TOKEN is an encrypted variable
+  # used in Appveyor CI config, originally created at
+  # multibuild-wheels-staging site
+  - cd ..\scikit-image
+  - pip install git+https://github.com/Anaconda-Server/anaconda-client
+  - IF NOT "%SKIMAGE_STAGING_UPLOAD_TOKEN%" == "" anaconda -t %SKIMAGE_STAGING_UPLOAD_TOKEN% upload --force -u %ANACONDA_ORG% "dist\*.whl"
 
 cache:
   # Avoid re-downloading large packages

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -95,7 +95,8 @@ on_success:
   # PYWAVELETS_STAGING_UPLOAD_TOKEN is an encrypted variable
   # used in Appveyor CI config, originally created at
   # multibuild-wheels-staging site
-  - cd ..\scikit-image
+  - dir
+  - cd scikit-image
   - pip install git+https://github.com/Anaconda-Server/anaconda-client
   - IF NOT "%SKIMAGE_STAGING_UPLOAD_TOKEN%" == "" anaconda -t %SKIMAGE_STAGING_UPLOAD_TOKEN% upload --force -u %ANACONDA_ORG% "dist\*.whl"
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -95,7 +95,6 @@ on_success:
   # PYWAVELETS_STAGING_UPLOAD_TOKEN is an encrypted variable
   # used in Appveyor CI config, originally created at
   # multibuild-wheels-staging site
-  - dir
   - cd scikit-image
   - pip install git+https://github.com/Anaconda-Server/anaconda-client
   - IF NOT "%SKIMAGE_STAGING_UPLOAD_TOKEN%" == "" anaconda -t %SKIMAGE_STAGING_UPLOAD_TOKEN% upload --force -u %ANACONDA_ORG% "dist\*.whl"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,6 @@ env:
       - NP_BUILD_DEP="numpy==1.14.5"
       - NP_TEST_DEP="numpy==1.14.5"
       - GEN_DEPS="matplotlib networkx scipy pillow"
-      - MANYLINUX_URL=https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com
-      - WHEELHOUSE_UPLOADER_USERNAME=travis-worker
-      # Following generated with
-      # travis encrypt -r scikit-image/scikit-image-wheels WHEELHOUSE_UPLOADER_SECRET=<the api key>
-      - secure: "PjnpdJj6BrEmiQO+Kq79wd/HGcn0hpIqkS5TcR/rnU6X6shrN6qnKXtM2oa94HLwi+Qus+c9RfBmu+zflqzh357SkmdF3Jwj36OzC2G6i6QEQGdDecr2RE8qBy2FwwkNDsxVPxduNMrWzejpWmeZt8j+qKbz2p2bwmUJmht0XqE="
       # Commit when running from daily branch
       - DAILY_COMMIT=master
 
@@ -72,11 +67,10 @@ matrix:
 
 before_install:
     - if [ "$TRAVIS_BRANCH" == "master" ]; then
-          CONTAINER="pre-release";
+          ANACONDA_ORG="scipy-wheels-nightly"
           BUILD_COMMIT=${DAILY_COMMIT:-$BUILD_COMMIT};
       else
-          CONTAINER=wheels;
-          UPLOAD_ARGS="--no-update-index";
+          ANACONDA_ORG="multibuild-wheels-staging"
       fi
     # The devel branch seems necessary for python 3.8 on OSX
     - git clone --depth 1 --branch devel https://github.com/matthew-brett/multibuild.git
@@ -96,9 +90,12 @@ script:
     - install_run $PLAT
 
 after_success:
-    # Upload wheels to Rackspace container
-    - pip install wheelhouse-uploader
-    - travis_wait 40 python -m wheelhouse_uploader upload
-          --local-folder ${TRAVIS_BUILD_DIR}/wheelhouse/
-          $UPLOAD_ARGS
-          $CONTAINER
+    # Upload the generated wheel package to anaconda.org
+    # SKIMAGE_STAGING_UPLOAD_TOKEN is an encrypted variable
+    # used in Appveyor CI config, originally created at
+    # multibuild-wheels-staging site
+    - TOKEN=${SKIMAGE_STAGING_UPLOAD_TOKEN};
+    - pip install git+https://github.com/Anaconda-Server/anaconda-client;
+    - if [ -n "${TOKEN}" ] ; then
+        anaconda -t ${TOKEN} upload -u ${ANACONDA_ORG} ${TRAVIS_BUILD_DIR}/wheelhouse/*.whl;
+      fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,10 +67,10 @@ matrix:
 
 before_install:
     - if [ "$TRAVIS_BRANCH" == "master" ]; then
-          ANACONDA_ORG="scipy-wheels-nightly"
+          ANACONDA_ORG="scipy-wheels-nightly";
           BUILD_COMMIT=${DAILY_COMMIT:-$BUILD_COMMIT};
       else
-          ANACONDA_ORG="multibuild-wheels-staging"
+          ANACONDA_ORG="multibuild-wheels-staging";
       fi
     # The devel branch seems necessary for python 3.8 on OSX
     - git clone --depth 1 --branch devel https://github.com/matthew-brett/multibuild.git

--- a/check_upload.sh
+++ b/check_upload.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Script to download / check and upload scikit_image wheels for release
-RACKSPACE_URL=http://a365fff413fe338398b6-1c8a9b3114517dc5fe17b7c3f8c63a43.r19.cf2.rackcdn.com
+ANACONDA_URL=https://pypi.anaconda.org/multibuild-wheels-staging/label/main/simple/scikit-image
 if [ "`which twine`" == "" ]; then
     echo "twine not on path; need to pip install twine?"
     exit 1
@@ -19,7 +19,7 @@ rm -rf *.whl
 for py_tag in cp27-none cp33-cp33m cp34-cp34m
 do
     wheel_name="$WHEEL_HEAD-$py_tag-$WHEEL_TAIL"
-    wheel_url="${RACKSPACE_URL}/${wheel_name}"
+    wheel_url="${ANACONDA_URL}/${wheel_name}"
     curl -O $wheel_url
     if [ "$?" != "0" ]; then
         echo "Failed downloading $wheel_url; check travis build?"

--- a/config.sh
+++ b/config.sh
@@ -4,7 +4,6 @@
 # Extra wheels points to directory with manylinux wheels not available on
 # pypi.
 export STAGING_WHEELS_URL="https://pypi.anaconda.org/multibuild-wheels-staging/label/main/simple/"
-export NIGHTLY_WHEELS_URL="https://pypi.anaconda.org/scipy-wheels-nightly/label/main/simple/"
 
 function pre_build {
     # Any stuff that you need to do before you start building the wheels
@@ -14,7 +13,7 @@ function pre_build {
 
 function pip_opts {
     # Define extra pip arguments
-    echo "--prefer-binary --extra-index-url $STAGING_WHEELS_URL  --extra-index-url $NIGHTLY_WHEELS_URL"
+    echo "--prefer-binary --extra-index-url $STAGING_WHEELS_URL"
 }
 
 function run_tests {

--- a/config.sh
+++ b/config.sh
@@ -2,10 +2,9 @@
 # Test for OSX with [ -n "$IS_OSX" ]
 
 # Extra wheels points to directory with manylinux wheels not available on
-# pypi.  For example, matplotlib does not distribute 32-bit wheels, but we
-# build and upload these via the 32-bit-builds branch of
-# https://github.com/MacPython/matplotlib-wheels
-EXTRA_WHEELS_URL=https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com
+# pypi.
+export STAGING_WHEELS_URL="https://pypi.anaconda.org/multibuild-wheels-staging/label/main/simple/"
+export NIGHTLY_WHEELS_URL="https://pypi.anaconda.org/scipy-wheels-nightly/label/main/simple/"
 
 function pre_build {
     # Any stuff that you need to do before you start building the wheels
@@ -15,7 +14,7 @@ function pre_build {
 
 function pip_opts {
     # Define extra pip arguments
-    echo "--prefer-binary --find-links $EXTRA_WHEELS_URL"
+    echo "--prefer-binary --extra-index-url $STAGING_WHEELS_URL  --extra-index-url $NIGHTLY_WHEELS_URL"
 }
 
 function run_tests {


### PR DESCRIPTION
This is an attempt at switching the uploads to anaconda.org as discussed in #42

I created a SKIMAGE_STAGING_UPLOAD_TOKEN token at [multibuild-wheels-staging](https://anaconda.org/multibuild-wheels-staging) and I think the same token also will work for [scipy-wheels-nightly](https://anaconda.org/scipy-wheels-nightly) if we want to keep any pre-release wheels there. Corresponding environment variables were created on Appveyor and Travis-CI.

The actual upload code here is based on what was used for PyWavelets, although the PR there did not support nightly wheels. I think I saw there was some logic to do that here so I tried to set which destination the wheels will be uploaded to accordingly.

To actually see if wheels are getting uploaded as expected will require merging this PR (I think this branch on my fork cannot see the environment variables, but they will be found once this is merged).


### Additional Details

I'm not sure we need the `--extra-index-url` in config.sh. It looks like maybe this was originally to help find 32-bit Matplotlib wheels for linux? If that is the case, this is not going to help for that because matplotlib doesn't currently have wheels at the URL specified there.
