### PR TITLE
retry at scipy-wheels-nightly

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,9 +32,11 @@ init:
   - ps: >-
       if ($env:APPVEYOR_REPO_BRANCH -eq "master") {
         $env:ANACONDA_ORG = "scipy-wheels-nightly"
+        $env:UPLOAD_TOKEN = $env:SKIMAGE_NIGHTLY_UPLOAD_TOKEN
         if ($env:DAILY_COMMIT) { $env:BUILD_COMMIT = $env:DAILY_COMMIT }
       } else {
         $env:ANACONDA_ORG = "multibuild-wheels-staging"
+        $env:UPLOAD_TOKEN = $env:SKIMAGE_STAGING_UPLOAD_TOKEN
       }
 
 install:
@@ -97,7 +99,7 @@ on_success:
   # multibuild-wheels-staging site
   - cd scikit-image
   - pip install git+https://github.com/Anaconda-Server/anaconda-client
-  - IF NOT "%SKIMAGE_STAGING_UPLOAD_TOKEN%" == "" anaconda -t %SKIMAGE_STAGING_UPLOAD_TOKEN% upload --force -u %ANACONDA_ORG% "dist\*.whl"
+  - IF NOT "%UPLOAD_TOKEN%" == "" anaconda -t %UPLOAD_TOKEN% upload --force -u %ANACONDA_ORG% "dist\*.whl"
 
 cache:
   # Avoid re-downloading large packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,10 +67,7 @@ matrix:
 
 before_install:
     - if [ "$TRAVIS_BRANCH" == "master" ]; then
-          ANACONDA_ORG="scipy-wheels-nightly";
           BUILD_COMMIT=${DAILY_COMMIT:-$BUILD_COMMIT};
-      else
-          ANACONDA_ORG="multibuild-wheels-staging";
       fi
     # The devel branch seems necessary for python 3.8 on OSX
     - git clone --depth 1 --branch devel https://github.com/matthew-brett/multibuild.git
@@ -94,8 +91,14 @@ after_success:
     # SKIMAGE_STAGING_UPLOAD_TOKEN is an encrypted variable
     # used in Appveyor CI config, originally created at
     # multibuild-wheels-staging site
-    - TOKEN=${SKIMAGE_STAGING_UPLOAD_TOKEN};
     - pip install git+https://github.com/Anaconda-Server/anaconda-client;
+    - if [ "$TRAVIS_BRANCH" == "master" ]; then
+          ANACONDA_ORG="scipy-wheels-nightly";
+          TOKEN=${SKIMAGE_NIGHTLY_UPLOAD_TOKEN};
+      else
+          ANACONDA_ORG="multibuild-wheels-staging";
+          TOKEN=${SKIMAGE_STAGING_UPLOAD_TOKEN};
+      fi
     - if [ -n "${TOKEN}" ] ; then
         anaconda -t ${TOKEN} upload -u ${ANACONDA_ORG} ${TRAVIS_BUILD_DIR}/wheelhouse/*.whl;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,8 @@ after_success:
     # multibuild-wheels-staging site
     - pip install git+https://github.com/Anaconda-Server/anaconda-client;
     - if [ "$TRAVIS_BRANCH" == "master" ]; then
+          source extra_functions.sh;
+          for f in wheelhouse/*.whl; do rename_wheel $f; done;
           ANACONDA_ORG="scipy-wheels-nightly";
           TOKEN=${SKIMAGE_NIGHTLY_UPLOAD_TOKEN};
       else

--- a/extra_functions.sh
+++ b/extra_functions.sh
@@ -1,10 +1,13 @@
 # wheel renaming utility copied from github.com/MacPython/scipy-wheels
 
 function rename_wheel {
-    # Call with a name like scipy-1.5.0.dev0+58dbafa-cp37-cp37m-linux_x86_64.whl
+    # Call with a name like
+    #      scikit_image-0.18.0.dev0+58dbafa-cp37-cp37m-linux_x86_64.whl
+    # And a new name with an inserted date will be generated. For example:
+    #      scikit_image-0.18.0.dev0+20201005161318_58dbafa-cp37-cp37m-linux_x86_64.whl
 
-    # Add a date after the dev0+ and before the hash in yyymmddHHMMSS format
-    # so pip will pick up the newest build. Try a little to make sure
+    # The date is added after the dev0+ and before the hash in yyymmddHHMMSS
+    # format so pip will pick up the newest build. Try a little to make sure
     # - the first part ends with 'dev0+'
     # - the second part starts with a lower case alphanumeric then a '-'
     # if those conditions are not met, the name will be returned as-is

--- a/extra_functions.sh
+++ b/extra_functions.sh
@@ -1,0 +1,16 @@
+# wheel renaming utility copied from github.com/MacPython/scipy-wheels
+
+function rename_wheel {
+    # Call with a name like scipy-1.5.0.dev0+58dbafa-cp37-cp37m-linux_x86_64.whl
+
+    # Add a date after the dev0+ and before the hash in yyymmddHHMMSS format
+    # so pip will pick up the newest build. Try a little to make sure
+    # - the first part ends with 'dev0+'
+    # - the second part starts with a lower case alphanumeric then a '-'
+    # if those conditions are not met, the name will be returned as-is
+
+    newname=$(echo "$1" | sed "s/\(.*dev0+\)\([a-z0-9]*-.*\)/\1$(date '+%Y%m%d%H%M%S_')\2/")
+    if [ "$newname" != "$1" ]; then
+        mv $1 $newname
+    fi
+}


### PR DESCRIPTION
I have created a second token and corresponding environment variables for scipy-wheels-nightly now.

I also added renaming based on timestamps to Travis-CI following the example from SciPy. One thing that is different is that I have left the current configuration here to upload to `scipy-wheels-nightly` whenever the branch is "master". SciPy instead uploads ALL merged PRs to `multibuild-wheels-staging` and only uploads weekly chron job builds to `scipy-wheels-nightly` ([see here](https://github.com/MacPython/scipy-wheels/blob/master/.travis.yml#L242) for how they detect a chron job vs. pull request).


