### PR TITLE
WIP/DO NOT MERGE   debug wheel renaming

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,16 +91,27 @@ after_success:
     # SKIMAGE_STAGING_UPLOAD_TOKEN is an encrypted variable
     # used in Appveyor CI config, originally created at
     # multibuild-wheels-staging site
-    - pip install git+https://github.com/Anaconda-Server/anaconda-client;
-    - if [ "$TRAVIS_BRANCH" == "master" ]; then
-          source extra_functions.sh;
-          for f in wheelhouse/*.whl; do rename_wheel $f; done;
-          ANACONDA_ORG="scipy-wheels-nightly";
-          TOKEN=${SKIMAGE_NIGHTLY_UPLOAD_TOKEN};
-      else
-          ANACONDA_ORG="multibuild-wheels-staging";
-          TOKEN=${SKIMAGE_STAGING_UPLOAD_TOKEN};
-      fi
-    - if [ -n "${TOKEN}" ] ; then
-        anaconda -t ${TOKEN} upload -u ${ANACONDA_ORG} ${TRAVIS_BUILD_DIR}/wheelhouse/*.whl;
-      fi
+
+    - |
+      source extra_functions.sh
+      echo "wheel files in wheelhouse/"
+      for f in wheelhouse/*.whl; do echo $f; done
+      echo "wheel files in ${TRAVIS_BUILD_DIR}/wheelhouse/"
+      for f in ${TRAVIS_BUILD_DIR}/wheelhouse/*.whl; do echo $f; done
+      for f in ${TRAVIS_BUILD_DIR}/wheelhouse/*.whl; do rename_wheel $f; done;
+      echo "renamed wheel files in ${TRAVIS_BUILD_DIR}/wheelhouse/"
+      for f in ${TRAVIS_BUILD_DIR}/wheelhouse/*.whl; do echo $f; done
+
+    # - pip install git+https://github.com/Anaconda-Server/anaconda-client;
+    # - if [ "$TRAVIS_BRANCH" == "master" ]; then
+    #       source extra_functions.sh;
+    #       for f in wheelhouse/*.whl; do rename_wheel $f; done;
+    #       ANACONDA_ORG="scipy-wheels-nightly";
+    #       TOKEN=${SKIMAGE_NIGHTLY_UPLOAD_TOKEN};
+    #   else
+    #       ANACONDA_ORG="multibuild-wheels-staging";
+    #       TOKEN=${SKIMAGE_STAGING_UPLOAD_TOKEN};
+    #   fi
+    # - if [ -n "${TOKEN}" ] ; then
+    #     anaconda -t ${TOKEN} upload -u ${ANACONDA_ORG} ${TRAVIS_BUILD_DIR}/wheelhouse/*.whl;
+    #   fi


### PR DESCRIPTION
The tokens worked for #44, but the linux and OS X wheels on https://anaconda.org/scipy-wheels-nightly/scikit-image/files do not have dates inserted in the filenames as expected.

I am currently trying to debug the wheel renaming on Travis-CI here