### PR TITLE
Add config to build aarch64 wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,42 @@ matrix:
         - MB_PYTHON_VERSION=3.8
         - NP_BUILD_DEP: "numpy==1.17.3"
         - NP_TEST_DEP: "numpy==1.17.3"
+    - os: linux
+      arch: arm64-graviton2
+      dist: focal
+      virt: vm
+      group: edge
+      env:
+        - MB_PYTHON_VERSION=3.6
+        - MB_ML_VER=2014
+        - PLAT=aarch64
+        - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+        - NP_BUILD_DEP="numpy==1.19.2"
+        - NP_TEST_DEP="numpy==1.19.2"
+    - os: linux
+      arch: arm64-graviton2
+      dist: focal
+      virt: vm
+      group: edge
+      env:
+        - MB_PYTHON_VERSION=3.7
+        - MB_ML_VER=2014
+        - PLAT=aarch64
+        - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+        - NP_BUILD_DEP="numpy==1.19.2"
+        - NP_TEST_DEP="numpy==1.19.2"
+    - os: linux
+      arch: arm64-graviton2
+      dist: focal
+      virt: vm
+      group: edge
+      env:
+        - MB_PYTHON_VERSION=3.8
+        - MB_ML_VER=2014
+        - PLAT=aarch64
+        - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+        - NP_BUILD_DEP="numpy==1.19.2"
+        - NP_TEST_DEP="numpy==1.19.2"
     - os: osx
       language: generic
       env:


### PR DESCRIPTION
Travis-CI allows for the creation of ARM64 wheels.
Successful build log: https://travis-ci.com/github/janaknat/scikit-image-wheels

Travis-CI also supports using Graviton2 for ARM builds. To do that, the repo would have to migrate to travis-ci.com from travis-ci.org.

Basic steps:
* go to settings ->installed github apps -> add the repo that wishes to migrate
* go to https://travis-ci.com/organizations/scikit-image/migrate, the repo should appear there. Authorize the transition.
* come back to a PR, close/open to restart the build.

More info at https://docs.travis-ci.com/user/migrate/open-source-repository-migration
